### PR TITLE
Added optional / regex to deal with cases of double // in src=""

### DIFF
--- a/src/helpers/convertDomainToRelativeHelper/convertDomainToRelativeHelper.js
+++ b/src/helpers/convertDomainToRelativeHelper/convertDomainToRelativeHelper.js
@@ -38,7 +38,7 @@ const convertDomainToRelativeHelper = (
     .substring(1);
 
   return output.replace(
-    new RegExp(`(src=")${urlToReplace}`, 'g'),
+    new RegExp(`(src=")${urlToReplace}/?`, 'g'),
     `$1${relativePathPrefix}`,
   ).replace(
     new RegExp(`(src=")${urlWithoutProtocol}`, 'g'),


### PR DESCRIPTION
I was running into issues where I had `img` tags that were originally `src="http://localhost:2368/content/....."` to be replaced with `./../..//content/.....` (note the double slashes).

This PR addresses that and gets rid of the double slash