### PR TITLE
Fetch resources used by the default 404 page

### DIFF
--- a/src/commands/generateStaticSite.js
+++ b/src/commands/generateStaticSite.js
@@ -3,6 +3,7 @@ const mkdirp = require('mkdirp');
 const { argv } = require('yargs');
 const previewGeneratedSite = require('./previewGeneratedSite');
 const fetchUrlHelper = require('../helpers/fetchUrlHelper');
+const copy404PageHelper = require('../helpers/copy404PageHelper');
 const removeQueryStringsHelper = require('../helpers/removeQueryStringsHelper');
 const responsiveImagesHelper = require('../helpers/responsiveImagesHelper/responsiveImagesHelper');
 const replaceUrlHelper = require('../helpers/replaceUrlHelper');
@@ -24,6 +25,10 @@ const generateStaticSite = () => {
         `${OPTIONS.DOMAIN}/sitemap.xsl`,
         `${OPTIONS.DOMAIN}/sitemap.xml`,
         `${OPTIONS.DOMAIN}/404`,
+        `${OPTIONS.DOMAIN}/public/ghost.css`,
+        `${OPTIONS.DOMAIN}/public/ghost.min.css`,
+        `${OPTIONS.DOMAIN}/public/404-ghost.png`,
+        `${OPTIONS.DOMAIN}/public/404-ghost@2x.png`,
       ];
 
       if (error) {
@@ -32,6 +37,11 @@ const generateStaticSite = () => {
       }
 
       urls.forEach(fetchUrlHelper);
+
+      /**
+       * Copy the 404 page to 404.html
+       */
+      copy404PageHelper();
 
       /**
        * Generate all missing responsive images

--- a/src/helpers/copy404PageHelper/copy404PageHelper.js
+++ b/src/helpers/copy404PageHelper/copy404PageHelper.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+const OPTIONS = require('../../constants/OPTIONS');
+
+const copy404PageHelper = () => {
+  const filePath = path.resolve(
+    process.cwd(),
+    `${OPTIONS.STATIC_DIRECTORY}/404/index.html`,
+  );
+  const newPath = path.resolve(
+    process.cwd(),
+    `${OPTIONS.STATIC_DIRECTORY}/404.html`,
+  );
+  fs.copyFileSync(filePath, newPath);
+};
+
+module.exports = copy404PageHelper;

--- a/src/helpers/copy404PageHelper/index.js
+++ b/src/helpers/copy404PageHelper/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./copy404PageHelper');


### PR DESCRIPTION
Also makes a copy to 404.html, which is accepted by both Github pages and Cloudflare pages as the page to show when there is a real 404.

See [Github Pages doc](https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-custom-404-page-for-your-github-pages-site) and [Cloudflare pages doc](https://developers.cloudflare.com/pages/platform/serving-pages)