### PR TITLE
Including root URL in base URL list

### DIFF
--- a/src/commands/generateStaticSite.js
+++ b/src/commands/generateStaticSite.js
@@ -22,6 +22,7 @@ const generateStaticSite = () => {
     `${OPTIONS.STATIC_DIRECTORY}/content`,
     (error) => {
       const urls = [
+        `${OPTIONS.DOMAIN}/`,
         `${OPTIONS.DOMAIN}/sitemap.xsl`,
         `${OPTIONS.DOMAIN}/sitemap.xml`,
         `${OPTIONS.DOMAIN}/404`,


### PR DESCRIPTION
In a recent change (unsure which) Ghost seems to no longer include the root URL (/) in the sitemap, so it doesn't get crawled by this script.