### PR TITLE
Add a switch to save assets using the referer url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ This option is intended for users who do no worry about SEO. This option will ma
 $ gssg --ignore-absolute-paths
 ```
 
+### Save redirected assets as referer path
+This option saves redirected content with the original referer path instead of the destination path. Note: from a file size perspective this is suboptimal as it results in each redirect saving a copy of the original file.
+```
+$ gssg --saveAsReferer
+```
+
 ## Contributing
 
 This is still a work in progress, please feel free to contribute by raising issues or creating pr's.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-static-site-generator",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A simple static site generator for ghost",
   "main": "index.js",
   "scripts": {

--- a/src/constants/OPTIONS.js
+++ b/src/constants/OPTIONS.js
@@ -6,6 +6,7 @@ const DOMAIN = argv.domain || 'http://localhost:2368';
 const URL = argv.url || 'http://localhost:2368';
 const IGNORE_ABSOLUTE_PATHS = argv.ignoreAbsolutePaths || false;
 const STATIC_DIRECTORY = argv.dest || 'static';
+const SAVE_AS_REFERER = argv.saveAsReferer || false;
 
 const shouldShowProgress = () => {
   if (argv.silent) {
@@ -41,6 +42,9 @@ const OPTIONS = {
     : '',
   // --ignore-absolute-paths flag will remove all urls
   IGNORE_ABSOLUTE_PATHS,
+  // --save-as-referer flag will save redirected assets using the
+  // original url path instead of the redirected destination url
+  SAVE_AS_REFERER,
 };
 
 module.exports = OPTIONS;

--- a/src/helpers/crawlPageAsyncHelper/crawlPageAsyncHelper.js
+++ b/src/helpers/crawlPageAsyncHelper/crawlPageAsyncHelper.js
@@ -13,6 +13,13 @@ const contentOnError = () => {
     : '';
 };
 
+const saveAsReferer = () => {
+  if (OPTIONS.SAVE_AS_REFERER) {
+    return '';
+  }
+  return '--trust-server-names ';
+};
+
 /**
  * A async version of crawlPageHelper
  */
@@ -26,8 +33,8 @@ const crawlPageAsyncHelper = (
     + '--no-parent '
     + '--no-host-directories '
     + '--restrict-file-name=unix '
-    + '--trust-server-names '
-    + `--directory-prefix ${OPTIONS.STATIC_DIRECTORY} ${contentOnError()}`
+    + `--directory-prefix ${OPTIONS.STATIC_DIRECTORY} ${contentOnError()} `
+    + `${saveAsReferer()}`
     + `${url}`;
 
   try {

--- a/src/helpers/crawlPageHelper/crawlPageHelper.js
+++ b/src/helpers/crawlPageHelper/crawlPageHelper.js
@@ -13,6 +13,13 @@ const contentOnError = () => {
     : '';
 };
 
+const saveAsReferer = () => {
+  if (OPTIONS.SAVE_AS_REFERER) {
+    return '';
+  }
+  return '--trust-server-names ';
+};
+
 const crawlPageHelper = (url) => {
   const wgetCommand = `wget -q ${OPTIONS.SHOW_PROGRESS_BAR}--recursive `
     + '--timestamping '
@@ -20,8 +27,8 @@ const crawlPageHelper = (url) => {
     + '--no-parent '
     + '--no-host-directories '
     + '--restrict-file-name=unix '
-    + '--trust-server-names '
-    + `--directory-prefix ${OPTIONS.STATIC_DIRECTORY} ${contentOnError()}`
+    + `--directory-prefix ${OPTIONS.STATIC_DIRECTORY} ${contentOnError()} `
+    + `${saveAsReferer()}`
     + `${url}`;
 
   try {


### PR DESCRIPTION
The `--trust-server-names` wget flag saves assets using the destination path of a redirect. This results in some broken links when generating a static site as redirects are not maintained.

An option to remove this flag has been added as a switch to keep the default configuration and prevent breaking changes.

Note: from a file size perspective this is suboptimal as it results in duplicate images being generated. It does however fix various image sizes that fail to generate due to redirects. [Ref Issue](https://github.com/Fried-Chicken/ghost-static-site-generator/issues/37)

Moved source branch of PR off main. This replaces https://github.com/Fried-Chicken/ghost-static-site-generator/pull/54