### PR TITLE
Make path handling os-independent

### DIFF
--- a/src/helpers/fetchUrlHelper/fetchUrlHelper.js
+++ b/src/helpers/fetchUrlHelper/fetchUrlHelper.js
@@ -34,8 +34,8 @@ const fetchUrlHelper = (url) => {
 
   if (`${url}`.includes('.xml')) {
     urlpath = url.replace(OPTIONS.SOURCE_DOMAIN, "")
-    urlpath = "\\" + urlpath.substring(1);
-    const fileName = `${OPTIONS.STATIC_DIRECTORY}${urlpath}`;
+    urlpath = path.sep + urlpath.substring(1);
+    const fileName = path.join(OPTIONS.STATIC_DIRECTORY, urlpath);
 
     try {
       const filePath = path.resolve(


### PR DESCRIPTION
Adjust this code to use OS-independent URL-to-path conversion rather than assuming Windows path separator
Tested on Linux
(Following CapChord/ghost-static-site-generator/commit/02d6d1b1)
