### PR TITLE
Avoid https redirects for the current site

### DIFF
--- a/src/constants/OPTIONS.js
+++ b/src/constants/OPTIONS.js
@@ -18,6 +18,7 @@ const PRODUCTION_DOMAIN = (argv.productionDomain || argv.url || SOURCE_DOMAIN).r
 const IGNORE_ABSOLUTE_PATHS = argv.ignoreAbsolutePaths || false;
 const STATIC_DIRECTORY = argv.dest || 'static';
 const SAVE_AS_REFERER = argv.saveAsReferer || false;
+const X_FORWARDED_PROTO = argv['avoid-https'] ? '--header="X-Forwarded-Proto: https" ' : '';
 
 const shouldShowProgress = () => {
   if (argv.silent) {
@@ -56,6 +57,8 @@ const OPTIONS = {
   // --save-as-referer flag will save redirected assets using the
   // original url path instead of the redirected destination url
   SAVE_AS_REFERER,
+  // --avoid-https will avoid redirects to https by setting X-Forwarded-Proto to https
+  X_FORWARDED_PROTO,
 };
 
 module.exports = OPTIONS;

--- a/src/constants/OPTIONS.js
+++ b/src/constants/OPTIONS.js
@@ -18,7 +18,7 @@ const PRODUCTION_DOMAIN = (argv.productionDomain || argv.url || SOURCE_DOMAIN).r
 const IGNORE_ABSOLUTE_PATHS = argv.ignoreAbsolutePaths || false;
 const STATIC_DIRECTORY = argv.dest || 'static';
 const SAVE_AS_REFERER = argv.saveAsReferer || false;
-const X_FORWARDED_PROTO = argv['avoid-https'] ? '--header="X-Forwarded-Proto: https" ' : '';
+const X_FORWARDED_PROTO = argv.avoidHttps ? '--header="X-Forwarded-Proto: https" ' : '';
 
 const shouldShowProgress = () => {
   if (argv.silent) {

--- a/src/helpers/crawlPageHelper/crawlPageHelper.js
+++ b/src/helpers/crawlPageHelper/crawlPageHelper.js
@@ -27,7 +27,7 @@ const crawlPageHelper = (url) => {
     return;
   }
   const wgetCommand = `wget -q ${OPTIONS.SHOW_PROGRESS_BAR}--recursive `
-    + '--header="X-Forwarded-Proto: https" '
+    + `${OPTIONS.X_FORWARDED_PROTO}`
     + '--timestamping '
     + '--page-requisites '
     + '--no-parent '

--- a/src/helpers/crawlPageHelper/crawlPageHelper.js
+++ b/src/helpers/crawlPageHelper/crawlPageHelper.js
@@ -27,6 +27,7 @@ const crawlPageHelper = (url) => {
     return;
   }
   const wgetCommand = `wget -q ${OPTIONS.SHOW_PROGRESS_BAR}--recursive `
+    + '--header="X-Forwarded-Proto: https" '
     + '--timestamping '
     + '--page-requisites '
     + '--no-parent '


### PR DESCRIPTION
I had a situation where http://localdomain:2368/robots.txt was auto-redirecting to https://localdomain:2368/robots.txt
That caused a problem as that port is not https compatible; it was obviously intended to only work for the main domain
(This is an out-of-the-box ghost install)
This option prevents the server from generating such redirects

I've made this optional although arguably it could just be done all the time